### PR TITLE
fix too many values to unpack (expected 2)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Usage
   # Example 2 (using prepare and get_authentciated_user).
   class MainHandler(BasicAuthMixin, RequestHandler):
       def prepare(self):
-          self.get_authenticated_user(realm='Protected', auth_func=credentials.get)
+          self.get_authenticated_user(check_credentials_func=credentials.get, realm='Protected')
 
       def get(self):
           self.write('Hello %s' % self._current_user)
@@ -52,8 +52,11 @@ Usage
   app.listen(8888)
   tornado.ioloop.IOLoop.current().start()
 
-  # curl --digest user1:pass1 -v http://localhost:8888  -> 200 OK
-  # curl --digest user2:pass2 -v http://localhost:8888  -> 401 Unauthorized
+  # curl --user user1:pass1 -v  http://localhost:8888  -> 200 OK
+  # curl --user user2:pass2 -v  http://localhost:8888  -> 401 Unauthorized
+  # Remove or comment second class
+  # curl --digest --user user1:pass1 -v http://localhost:8888  -> 200 OK
+  # curl --digest --user user2:pass2 -v http://localhost:8888  -> 401 Unauthorized
 
 
 License

--- a/tornado_http_auth.py
+++ b/tornado_http_auth.py
@@ -207,7 +207,7 @@ class BasicAuthMixin(object):
 
         auth_data = auth_header.split(None, 1)[-1]
         auth_data = base64.b64decode(auth_data).decode('ascii')
-        username, password = auth_data.split(':')
+        username, password = auth_data.split(':',maxsplit=1)
 
         challenge = check_credentials_func(username)
         if not challenge:

--- a/tornado_http_auth.py
+++ b/tornado_http_auth.py
@@ -207,7 +207,7 @@ class BasicAuthMixin(object):
 
         auth_data = auth_header.split(None, 1)[-1]
         auth_data = base64.b64decode(auth_data).decode('ascii')
-        username, password = auth_data.split(':',maxsplit=1)
+        username, password = auth_data.split(':', 1)
 
         challenge = check_credentials_func(username)
         if not challenge:


### PR DESCRIPTION
When a user put : (colon) on user name or password this packages produces this error.
too many values to unpack (expected 2), line 210, in authenticate_user username, password = auth_data.split(':')
It can be fixed simply by checking the number of colons if colon is prohibited in user name and password.