### PR TITLE
SendChallange when digest verification failed to retry auth.

### DIFF
--- a/tornado_http_auth.py
+++ b/tornado_http_auth.py
@@ -56,8 +56,11 @@ class DigestAuthMixin(object):
 
         params = self.parse_auth_header(auth_header)
 
-        self.verify_params(params)
-        self.verify_opaque(params['opaque'], params['nonce'], self.request.remote_ip)
+        try:
+            self.verify_params(params)
+            self.verify_opaque(params['opaque'], params['nonce'], self.request.remote_ip)
+        except AuthError:
+            raise self.SendChallenge()
 
         challenge = check_credentials_func(params['username'])
         if not challenge:


### PR DESCRIPTION
Hi. @gvalkov 
I think that it is better implementation that SendChallenge is called when header verification is failed with digest auth method.
Otherwise, http status code is 500 and then web browser cannot prompt Callenge box anymore if login information is expired.
